### PR TITLE
Fixes issue #1

### DIFF
--- a/convert.go
+++ b/convert.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+	"strings"
 
 	"golang.org/x/image/bmp"
 	"golang.org/x/image/tiff"
@@ -75,7 +76,7 @@ func convertFile(wg *sync.WaitGroup, currPath string, outputDir string, fileType
 	// call done when finished
 	defer wg.Done()
 
-	ext := filepath.Ext(currPath)
+	ext := strings.ToLower(filepath.Ext(currPath))
 	newExt := getFileExtension(fileType)
 
 	_, filename := filepath.Split(currPath)


### PR DESCRIPTION
This fix for issue #1 just uses the Go "strings" library to convert the file extension to all lowercase characters in the event that the extension contains capital letters.

![screen shot 2017-05-26 at 12 59 32 pm](https://cloud.githubusercontent.com/assets/27779755/26506743/31f33e04-4213-11e7-98dc-011ffc1b78b8.png)